### PR TITLE
improvement(test): increase test timeouts

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,9 +1,13 @@
 import { runAction } from '../runner'
 
 describe('index', () => {
-  it('should work [integration]', async () => {
-    await runAction(
-      'https://cdn.jsdelivr.net/gh/overlayed-app/remote-overlay-test@1.1.0/index.js'
-    )
-  })
+  it(
+    'should work [integration]',
+    async () => {
+      await runAction(
+        'https://cdn.jsdelivr.net/gh/overlayed-app/remote-overlay-test@1.1.0/index.js'
+      )
+    },
+    15 * 1000 /* 15 seconds */
+  )
 })


### PR DESCRIPTION
This allows our integration tests to take a bit longer without timing out - which is great, given
they depend on the network.

fix #3